### PR TITLE
Remove `yeoman-generator` from keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "url": "https://github.com/Sashmac/neat-starter-template"
   },
   "keywords": [
-    "yeoman-generator",
     "bourbon",
     "neat",
     "pure",


### PR DESCRIPTION
Please remove `yeoman-generator` from the keywords.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/andrew-mccarthy/neat-starter-template/1)

<!-- Reviewable:end -->
